### PR TITLE
Remove pass-by-reference from processRawFieldData call for PHP 5.4+

### DIFF
--- a/fields/field.incremental_number.php
+++ b/fields/field.incremental_number.php
@@ -56,7 +56,7 @@
 		public function processRawFieldData($data, &$status, $message, $simulate = false, $entry_id = null){
 			if( !$data ) $data = $this->getNewNumber();
 
-			return parent::processRawFieldData($data, &$status, $message, $simulate, $entry_id);
+			return parent::processRawFieldData($data, $status, $message, $simulate, $entry_id);
 		}
 
 		public function getNewNumber(){


### PR DESCRIPTION
Fixes #5.

Note: I have tested basic use of this extension since making the change, but I don't fully understand the reasons and implications of call-by-reference so please check.
